### PR TITLE
Tweaks to API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,20 @@ operations: Summation, Multiplication and Division.
 The format of the input JSON should follow this schema:
 
 ```
+{
    "program_code":[
-      "Madrid_initial_state_pulse",
       10,
-      "Madrid_pulse_1",
-      "Madrid_pulse_2",
+      "Madrid_initial_state_pulse",
       120,
-      "Madrid_pulse_2",
-      "Madrid_pulse_1",
       "Madrid_pulse_1",
       3,
       "Madrid_pulse_2",
       "Madrid_pulse_2",
-      2
+      2,
+      "Madrid_pulse_2",
+      "Madrid_pulse_1"
    ]
+}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ at all.
 This is the endpoint for loading a program: 
 
 ```
-POST /load_program
+POST /program/load
 ```
-
 
 The input of the service is a sequence of pulses and values that will map to some simple algebraic
 operations: Summation, Multiplication and Division.
@@ -38,19 +37,26 @@ The format of the input JSON should follow this schema:
 ```
 
 
-This is the endpoint for triggering the execution of the program:
-
-```
-GET /run_program/<program_id>
-```
-
-
 In case of success, the HTTP code will be 200 and the response JSON will be:
 ```
 {
      "program_id": "MadridProgramId1"
 }
 ```
+
+This is the endpoint for triggering the execution of the program:
+
+```
+GET /program/run/<program_id>
+```
+
+In case of success, the HTTP code will be 200 and the response JSON will be:
+```
+{
+     "result": 195
+}
+```
+
 
 ### Workflow
 
@@ -61,8 +67,8 @@ later call to the `/run_program` endpoint so the service identifies the program 
 
 This implies two REST calls:
 ```
-POST /load_program {...}
-GET /run_program/<program_id>
+POST /program/load {...}
+GET /program/run/<program_id>
 ```
 
 ## Installing and running the application

--- a/madrid_instruments_service/tests/test_load_program.py
+++ b/madrid_instruments_service/tests/test_load_program.py
@@ -16,7 +16,10 @@ class TestLoadProgram(unittest.TestCase):
         self.client = TestClient(app)
 
     def test_load_program_returns_ok(self):
-        pulse_sequence = '{"program_code": [10,  "Madrid_initial_state_pulse", 120, "Madrid_pulse_1", 3, "Madrid_pulse_2", "Madrid_pulse_2", 2, "Madrid_pulse_2", "Madrid_pulse_1"]}'
+        pulse_sequence = (
+            '{"program_code": [10,  "Madrid_initial_state_pulse", 120, "Madrid_pulse_1", 3,'
+            '"Madrid_pulse_2", "Madrid_pulse_2", 2, "Madrid_pulse_2", "Madrid_pulse_1"]}'
+        )
         json_pulses = json.loads(pulse_sequence)
         response = self.client.post("/program/load", json=json_pulses)
         assert response.status_code == 200


### PR DESCRIPTION
Fixes #1 

Address a couple of item in the `README.md` (thanks Rainer for raising them):
* update the endpoint URLs
* revise the example input .json (along with a small formatting tweak in the test, to prevent long lines)

Additionally, added the output of `GET /program/run/<program_id>` for clarity - as previously there was some ambiguity over which endpoint the existing output corresponded to.